### PR TITLE
Fix issue #8 - move labels to left and fix also TOC dialog window.

### DIFF
--- a/_utilities/createToc.js
+++ b/_utilities/createToc.js
@@ -6,6 +6,7 @@ function createToc(eleventyConfig) {
         ignoredHeadings: ["[data-toc-exclude]"],
         ignoredElements: [".header-anchor"],
         ul: false,
+        wrapper: (toc) => toc,
     });
 }
 

--- a/_utilities/createToc.js
+++ b/_utilities/createToc.js
@@ -6,13 +6,6 @@ function createToc(eleventyConfig) {
         ignoredHeadings: ["[data-toc-exclude]"],
         ignoredElements: [".header-anchor"],
         ul: false,
-        wrapper: function (toc) {
-            return `<div class="overlay transparent"></div>
-                <dialog class="right" id="dialog-toc">
-                    <h5>Table of Contents</h5>
-                    <div class="toc vertical-padding">${toc}</div>
-                </dialog>`;
-        }
     });
 }
 

--- a/src/_includes/components/brutalism.css
+++ b/src/_includes/components/brutalism.css
@@ -392,6 +392,7 @@ body {
     z-index: 99 !important;
 }
 dialog.brutal-dialog {
+    display: none;
     position: fixed;
     top: 0; bottom: 0; left: 0;
     margin: 0;
@@ -406,7 +407,11 @@ dialog.brutal-dialog {
     border-right: var(--border-thick) !important;
     padding: 0 !important;
     box-shadow: 10px 0px 0px rgba(0,0,0,0.5) !important;
-    overflow-y: auto;
+    flex-direction: column;
+    overflow: hidden;
+}
+dialog.brutal-dialog[open] {
+    display: flex;
 }
 dialog.brutal-dialog-right {
     left: auto;
@@ -418,10 +423,10 @@ dialog.brutal-dialog-right {
 dialog.brutal-dialog-large {
     max-width: 800px;
 }
-dialog.brutal-dialog::-webkit-scrollbar { width: 8px; }
-dialog.brutal-dialog::-webkit-scrollbar-track { background: var(--bg-dark); }
-dialog.brutal-dialog::-webkit-scrollbar-thumb { background: #3f3f46; border-radius: 4px; }
-dialog.brutal-dialog::-webkit-scrollbar-thumb:hover { background: var(--primary-color); }
+dialog.brutal-dialog ::-webkit-scrollbar { width: 8px; }
+dialog.brutal-dialog ::-webkit-scrollbar-track { background: var(--bg-dark); }
+dialog.brutal-dialog ::-webkit-scrollbar-thumb { background: #3f3f46; border-radius: 4px; }
+dialog.brutal-dialog ::-webkit-scrollbar-thumb:hover { background: var(--primary-color); }
 
 .brutal-dialog-header {
     background: var(--bg-dark);
@@ -473,9 +478,10 @@ dialog.brutal-dialog::-webkit-scrollbar-thumb:hover { background: var(--primary-
     gap: 0.5rem;
 }
 .brutal-dialog-content {
-    padding: 6rem 1.5rem 2rem 1.5rem;
+    padding: 1.5rem;
     overflow-y: auto;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
 }
 .brutal-dialog-grid {
     display: grid;
@@ -486,6 +492,8 @@ dialog.brutal-dialog::-webkit-scrollbar-thumb:hover { background: var(--primary-
 .brutal-toc {
     padding: 1.5rem;
     overflow-y: auto;
+    flex: 1;
+    min-height: 0;
 }
 .brutal-toc ol {
     list-style: none;

--- a/src/_includes/components/brutalism.css
+++ b/src/_includes/components/brutalism.css
@@ -377,6 +377,14 @@ body {
 .brutal-icon-btn:hover .brutal-tooltip-right {
     transform: translateY(-50%) translateX(0);
 }
+.brutal-tooltip-left {
+    right: 130%;
+    top: 50%;
+    transform: translateY(-50%) translateX(5px);
+}
+.brutal-icon-btn:hover .brutal-tooltip-left {
+    transform: translateY(-50%) translateX(0);
+}
 
 .brutal-overlay {
     backdrop-filter: blur(8px) !important;
@@ -397,7 +405,15 @@ dialog.brutal-dialog {
     border: none !important;
     border-right: var(--border-thick) !important;
     padding: 0 !important;
-    box-shadow: 10px 0px 0px rgba(0,0,0,0.5) !important; 
+    box-shadow: 10px 0px 0px rgba(0,0,0,0.5) !important;
+    overflow-y: auto;
+}
+dialog.brutal-dialog-right {
+    left: auto;
+    right: 0;
+    border-right: none !important;
+    border-left: var(--border-thick) !important;
+    box-shadow: -10px 0px 0px rgba(0,0,0,0.5) !important;
 }
 dialog.brutal-dialog-large {
     max-width: 800px;
@@ -413,6 +429,17 @@ dialog.brutal-dialog::-webkit-scrollbar-thumb:hover { background: var(--primary-
     z-index: 10;
     position: sticky;
     top: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+}
+.brutal-dialog-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    color: #fff;
 }
 .brutal-dialog-nav {
     display: flex;
@@ -454,6 +481,45 @@ dialog.brutal-dialog::-webkit-scrollbar-thumb:hover { background: var(--primary-
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 1.5rem;
+}
+
+.brutal-toc {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+.brutal-toc ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.brutal-toc ol ol {
+    padding-left: 1rem;
+    border-left: 2px solid #3f3f46;
+    margin-top: 0.25rem;
+}
+.brutal-toc li {
+    margin: 0.4rem 0;
+}
+.brutal-toc a {
+    display: block;
+    color: #a1a1aa;
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 700;
+    padding: 0.3rem 0.5rem;
+    border-radius: 4px;
+    transition: color 0.15s ease, background 0.15s ease;
+}
+.brutal-toc a:hover {
+    color: var(--primary-color);
+    background: rgba(41, 182, 246, 0.08);
+}
+.brutal-toc > ol > li > a {
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 .bento-card-compact {
     min-height: auto !important;

--- a/src/_includes/components/brutalism.css
+++ b/src/_includes/components/brutalism.css
@@ -434,10 +434,6 @@ dialog.brutal-dialog ::-webkit-scrollbar-thumb:hover { background: var(--primary
     z-index: 10;
     position: sticky;
     top: 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.5rem;
 }
 .brutal-dialog-header h3 {
     margin: 0;

--- a/src/_includes/components/brutalism.js
+++ b/src/_includes/components/brutalism.js
@@ -19,7 +19,12 @@
     const overlays = document.querySelectorAll(".overlay");
     overlays.forEach((overlay) => {
       overlay.addEventListener("click", () => {
-        closeAllDialogs();
+        const sibling = overlay.nextElementSibling;
+        if (sibling && sibling.tagName === "DIALOG" && sibling.open) {
+          closeDialog(sibling);
+        } else {
+          closeAllDialogs();
+        }
       });
     });
 
@@ -38,11 +43,19 @@
     }
   }
 
+  function getOverlay(dialog) {
+    const sibling = dialog.previousElementSibling;
+    if (sibling && sibling.classList.contains("overlay")) {
+      return sibling;
+    }
+    return null;
+  }
+
   function openDialog(dialog) {
     dialog.showModal();
     dialog.classList.add("active");
 
-    const overlay = document.querySelector(".overlay");
+    const overlay = getOverlay(dialog);
     if (overlay) {
       overlay.classList.add("active");
     }
@@ -54,12 +67,13 @@
     dialog.close();
     dialog.classList.remove("active");
 
+    const overlay = getOverlay(dialog);
+    if (overlay) {
+      overlay.classList.remove("active");
+    }
+
     const openDialogs = document.querySelectorAll("dialog[open]");
     if (openDialogs.length === 0) {
-      const overlay = document.querySelector(".overlay");
-      if (overlay) {
-        overlay.classList.remove("active");
-      }
       document.body.style.overflow = "";
     }
   }

--- a/src/_includes/components/brutalism.js
+++ b/src/_includes/components/brutalism.js
@@ -148,6 +148,18 @@
     });
   }
 
+  function initTocLinks() {
+    const tocDialog = document.getElementById("dialog-toc");
+    if (!tocDialog) return;
+
+    tocDialog.addEventListener("click", (e) => {
+      const link = e.target.closest("a[href^='#']");
+      if (link) {
+        closeDialog(tocDialog);
+      }
+    });
+  }
+
   window.mode = toggleMode;
   window.theme = setTheme;
 
@@ -155,5 +167,6 @@
     initTheme();
     initDialogs();
     initMenus();
+    initTocLinks();
   });
 })();

--- a/src/_includes/components/dialog-tags.njk
+++ b/src/_includes/components/dialog-tags.njk
@@ -24,7 +24,7 @@
         <ul class="brutal-tag-list">
             {% for tag in collections.tagsList %}
             <li class="brutal-tag-item">
-                <a class="brutal-tag-link{% if page.url == '/tags/' ~ (tag | slug) ~ '/' %} active{% endif %}" data-ui="#dialog-tags" href="/tags/{{ tag | slug }}/">
+                <a class="brutal-tag-link{% if page.url == '/tags/' ~ (tag | slug) ~ '/' %} active{% endif %}" href="/tags/{{ tag | slug }}/">
                     <i>{% icon "lucide:hash" %}</i>
                     {{ tag }}
                 </a>       

--- a/src/_includes/components/post-buttons.njk
+++ b/src/_includes/components/post-buttons.njk
@@ -1,14 +1,14 @@
 <div class="brutal-fab-panel">
     <button class="brutal-icon-btn" data-ui="#dialog-toc" aria-label="Spis zawartości">
         <i>{% icon "lucide:table-of-contents" %}</i>
-        <span class="brutal-tooltip brutal-tooltip-right">Spis zawartości</span>
+        <span class="brutal-tooltip brutal-tooltip-left">Spis zawartości</span>
     </button>
     <a href="#top" class="brutal-icon-btn" aria-label="Wróć na początek strony">
         <i>{% icon "lucide:arrow-up" %}</i>
-        <span class="brutal-tooltip brutal-tooltip-right">Wróć na początek</span>
+        <span class="brutal-tooltip brutal-tooltip-left">Wróć na początek</span>
     </a>
     <a href="https://github.com/{{ site.ghRepo }}/issues" class="brutal-icon-btn" aria-label="Utwórz Issue">
         <i>{% icon "lucide:bug" %}</i>
-        <span class="brutal-tooltip brutal-tooltip-right">Utwórz Issue</span>
+        <span class="brutal-tooltip brutal-tooltip-left">Utwórz Issue</span>
     </a>
 </div>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -85,6 +85,7 @@ layout: layouts/default.njk
     {{ content | safe }}
 </article>
 
+<div class="overlay brutal-overlay"></div>
 <dialog id="dialog-toc" class="brutal-dialog brutal-dialog-right">
     <div class="brutal-dialog-header">
         <h3>Spis zawartości</h3>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -85,14 +85,14 @@ layout: layouts/default.njk
     {{ content | safe }}
 </article>
 
-<dialog id="dialog-toc" class="brutal-dialog">
+<dialog id="dialog-toc" class="brutal-dialog brutal-dialog-right">
     <div class="brutal-dialog-header">
         <h3>Spis zawartości</h3>
         <button class="brutal-icon-btn" data-ui="#dialog-toc" aria-label="Zamknij">
             <i>{% icon "lucide:x" %}</i>
         </button>
     </div>
-    <div class="brutal-content">
+    <nav class="brutal-toc">
         {{ content | toc | safe }}
-    </div>
+    </nav>
 </dialog>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -88,10 +88,12 @@ layout: layouts/default.njk
 <div class="overlay brutal-overlay"></div>
 <dialog id="dialog-toc" class="brutal-dialog brutal-dialog-right">
     <div class="brutal-dialog-header">
-        <h3>Spis zawartości</h3>
-        <button class="brutal-icon-btn" data-ui="#dialog-toc" aria-label="Zamknij">
-            <i>{% icon "lucide:x" %}</i>
-        </button>
+        <nav class="brutal-dialog-nav">
+            <h3>Spis zawartości</h3>
+            <button class="brutal-icon-btn" data-ui="#dialog-toc" aria-label="Zamknij">
+                <i>{% icon "lucide:x" %}</i>
+            </button>
+        </nav>
     </div>
     <nav class="brutal-toc">
         {{ content | toc | safe }}


### PR DESCRIPTION
- [x] Identify double padding issue: `.brutal-dialog-header` and `.brutal-dialog-nav` both declared flex layout and padding; existing dialogs nest nav inside header causing double padding.
- [x] Remove `display:flex`, `justify-content:space-between`, `align-items:center`, and `padding:1rem 1.5rem` from `.brutal-dialog-header` — now only provides background, border, and sticky positioning.
- [x] Update TOC dialog in `post.njk` to wrap header content in `<nav class="brutal-dialog-nav">` for consistency with all other dialog components.
- [x] Code review passed with no comments.

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/KamilGolis/KamilGolis.github.io/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
